### PR TITLE
Handle packages marked with LTI and other insurance types

### DIFF
--- a/web_resources/FME_exporter.js
+++ b/web_resources/FME_exporter.js
@@ -244,6 +244,7 @@ $(function () {
 
                 if (/Lifetime\s+Insurance/i.test(bonus)) {
                     insuranceType = INSURANCE_TYPE_LTI;
+                    return false; // LTI trumps other insurance types
                 } else if (/IAE\s+Insurance/i.test(bonus)) {
                     insuranceType = INSURANCE_TYPE_IAE;
                 } else {


### PR DESCRIPTION
It is possible for some packages to be marked as Lifetime Insurance and another type of insurnace at the same time.

https://cdn.discordapp.com/attachments/745260306330026034/780738702463860766/unknown.png

In my case this was because a package with LTI was upgraded with a special CCU that was meant to upgrade the standard insurance to IAE insurance (later changed to 120 month insurance). When I asked support about this, they said that the extra 120 month insurance would be removed later.

As such I think the extension should allow LTI to trump other types of insurance, rather than displaying only the last type listed on a package.